### PR TITLE
Add support to leap.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ require("no-clown-fiesta").setup({
 - Git
 - Hop
 - Lir
+- Leap
 - LSP
 - Lualine
 - Markdown

--- a/doc/no-clown-fiesta.txt
+++ b/doc/no-clown-fiesta.txt
@@ -48,6 +48,7 @@ SUPPORTED PLUGINS                              *no-clown-fiesta-supported_plugin
 *   Alpha
 *   Git
 *   Hop
+*   Leap
 *   Lir
 *   LSP
 *   Lualine

--- a/lua/no-clown-fiesta/groups/init.lua
+++ b/lua/no-clown-fiesta/groups/init.lua
@@ -4,6 +4,7 @@ return {
   require "no-clown-fiesta.groups.highlights",
   require "no-clown-fiesta.groups.hop",
   require "no-clown-fiesta.groups.lazy",
+  require "no-clown-fiesta.groups.leap",
   require "no-clown-fiesta.groups.lir",
   require "no-clown-fiesta.groups.lsp",
   require "no-clown-fiesta.groups.markdown",

--- a/lua/no-clown-fiesta/groups/leap.lua
+++ b/lua/no-clown-fiesta/groups/leap.lua
@@ -1,0 +1,12 @@
+local M = {}
+
+function M.highlight(palette, opts)
+    return {
+        LeapMatch = { fg = palette.cyan, bold = true },
+        LeapLabelPrimary = { fg = palette.red, bold = true },
+        LeapLabelSecondary = { fg = palette.gray_blue },
+        LeapBackdrop = { fg = palette.gray },
+    }
+end
+
+return M


### PR DESCRIPTION
First of all, thank you for coming up with the color scheme. It's the one color scheme I was able to stick with without the constant itch every two months to switch to something else.

I am adding support to [leap.nvim](https://github.com/ggandor/leap.nvim) in this PR.

I based the colors off what you already had for Hop.

![image](https://user-images.githubusercontent.com/14054804/232267346-6cdcea3c-712c-41cd-8883-5051ca2a4046.png)
