### PR TITLE
Set lualine inactive colors to gray

### DIFF
--- a/lua/lualine/themes/no-clown-fiesta.lua
+++ b/lua/lualine/themes/no-clown-fiesta.lua
@@ -3,6 +3,7 @@
 local colors = {
   bg = "#171717",
   fg = "#D0D0D0",
+  gray = "#373737",
 }
 
 return {
@@ -16,8 +17,8 @@ return {
   command = { a = { fg = colors.fg, bg = colors.bg, gui = "bold" } },
   replace = { a = { fg = colors.fg, bg = colors.bg, gui = "bold" } },
   inactive = {
-    a = { fg = colors.fg, bg = colors.bg },
-    b = { fg = colors.fg, bg = colors.bg },
-    c = { fg = colors.fg, bg = colors.bg },
+    a = { fg = colors.gray, bg = colors.bg },
+    b = { fg = colors.gray, bg = colors.bg },
+    c = { fg = colors.gray, bg = colors.bg },
   },
 }


### PR DESCRIPTION
For example, the tabs component should look like this now:
<img width="246" alt="Screenshot 2024-10-06 at 1 15 14 PM" src="https://github.com/user-attachments/assets/b53dfd89-3333-4aa0-864f-c8d00f55aba8">
