### PR TITLE
Add mini.statusline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,4 @@ Other plugin managers are left as an exercise to the reader.
 - Telescope
 - Treesitter
 - WhichKey
+- mini.statusline

--- a/doc/no-clown-fiesta.txt
+++ b/doc/no-clown-fiesta.txt
@@ -60,4 +60,5 @@ SUPPORTED PLUGINS                              *no-clown-fiesta-supported_plugin
 *   Treesitter
 *   StatusLine (the default non custom one)
 *   WhichKey
+*   Mini.statusline
 

--- a/lua/no-clown-fiesta/groups/init.lua
+++ b/lua/no-clown-fiesta/groups/init.lua
@@ -11,6 +11,7 @@ return {
   require "no-clown-fiesta.groups.lsp",
   require "no-clown-fiesta.groups.markdown",
   require "no-clown-fiesta.groups.mason",
+  require "no-clown-fiesta.groups.mini-statusline",
   require "no-clown-fiesta.groups.neogit",
   require "no-clown-fiesta.groups.neotest",
   require "no-clown-fiesta.groups.noice",

--- a/lua/no-clown-fiesta/groups/mini-statusline.lua
+++ b/lua/no-clown-fiesta/groups/mini-statusline.lua
@@ -1,0 +1,12 @@
+local M = {}
+
+function M.highlight(palette, opts)
+  return {
+    MiniStatuslineFilename = { fg = palette.light_gray, bg = palette.bg },
+    MiniStatuslineDevinfo = { fg = palette.medium_gray, bg = palette.bg },
+    MiniStatuslineFileinfo = { fg = palette.medium_gray, bg = palette.bg },
+    MiniStatuslineInactive = { fg = palette.gray, bg = palette.bg },
+  }
+end
+
+return M


### PR DESCRIPTION
Adding support for [mini.statusline](https://github.com/echasnovski/mini.statusline?tab=readme-ov-file#features).

I change some of the highlight groups to make the text visible.

Before:
![2024-10-27-191117_hyprshot](https://github.com/user-attachments/assets/352c175e-c6af-4179-8fe7-6be62682f215)


After:
![2024-10-27-191053_hyprshot](https://github.com/user-attachments/assets/9afc3772-51eb-42b9-bb01-0e98f17565d6)

