### PR TITLE
Blink.cmp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Other plugin managers are left as an exercise to the reader.
 - Neogit
 - Neotest
 - NvimCmp
+- BlinkCmp
 - NvimTree
 - Orgmode
 - StatusLine

--- a/lua/no-clown-fiesta/groups/blink.lua
+++ b/lua/no-clown-fiesta/groups/blink.lua
@@ -1,0 +1,19 @@
+local M = {}
+
+function M.highlight(palette, _)
+  return {
+    BlinkCmpMenu = { fg = palette.medium_gray },
+    BlinkCmpMenuBorder = { fg = palette.white },
+    BlinkCmpMenuSelection = { bg = palette.accent },
+    BlinkCmpLabel = { fg = palette.white },
+    BlinkCmpLabelMatch = { fg = palette.orange },
+    BlinkCmpLabelDetail = { fg = palette.medium_gray },
+    BlinkCmpLabelDeprecated = { fg = palette.medium_gray, strikethrough = true },
+    BlinkCmpLabelDescription = { fg = palette.medium_gray },
+    BlinkCmpKind = { fg = palette.light_gray },
+    BlinkCmpSource = { fg = palette.medium_gray },
+    BlinkCmpGhostText = { fg = palette.medium_gray },
+  }
+end
+
+return M

--- a/lua/no-clown-fiesta/groups/init.lua
+++ b/lua/no-clown-fiesta/groups/init.lua
@@ -15,6 +15,7 @@ return {
   require "no-clown-fiesta.groups.neotest",
   require "no-clown-fiesta.groups.noice",
   require "no-clown-fiesta.groups.nvim-cmp",
+  require "no-clown-fiesta.groups.blink",
   require "no-clown-fiesta.groups.nvim-tree",
   require "no-clown-fiesta.groups.orgmode",
   require "no-clown-fiesta.groups.statusline",


### PR DESCRIPTION
Hey! I added some groups for https://github.com/Saghen/blink.cmp

It should look similar to `nvim-cmp`

![image](https://github.com/user-attachments/assets/df87aefc-12d8-4bdc-a7f1-98d89e3b3280)

using this config (lazy)

```lua
local M = { 'saghen/blink.cmp' }

M.version = '*'
M.event = 'InsertEnter'
M.dependencies = 'rafamadriz/friendly-snippets'
M.opts = {
  completion = {
    menu = {
      border = 'rounded',
      draw = {
        columns = { -- Imitate 'nvim-cmp'
          { 'label' },
          { 'kind_icon', 'kind', gap = 1 },
          { 'label_description' },
        },
      },
    },
    documentation = {
      auto_show = true,
      window = { border = 'rounded' },
    },
  },
  keymap = {
    preset = 'none',
    ['<C-f>'] = { 'accept' },
    ['<C-p>'] = { 'select_prev' },
    ['<C-n>'] = { 'select_next' },
    ['<C-u>'] = { 'scroll_documentation_up' },
    ['<C-d>'] = { 'scroll_documentation_down' },
    ['<C-e>'] = { 'cancel' },
  },
}

function M.config(_, opts)
  require('blink.cmp').setup(opts)
end

return M

-- vim: ts=2 sts=2 sw=2 et

```

All highlight groups are defined here: https://cmp.saghen.dev/configuration/appearance.html#highlight-groups

Feel free to tell me if I should add any other