### PR TITLE
Fix: correct require path in colors file

### DIFF
--- a/colors/no-clown-fiesta.lua
+++ b/colors/no-clown-fiesta.lua
@@ -1,1 +1,1 @@
-require("lua.lualine.themes.no-clown-fiesta-low-contrast").load()
+require("no-clown-fiesta").load()


### PR DESCRIPTION
## Problem
The colors/no-clown-fiesta.lua file contains an incorrect require statement that causes the colorscheme to fail loading.

### Error
```
E5113: Error while calling lua chunk: module 'lua.lualine.themes.no-clown-fiesta-low-contrast' not found
```

## Solution
Changed the require path from:
```lua
require("lua.lualine.themes.no-clown-fiesta-low-contrast").load()
```

To the correct path:
```lua
require("no-clown-fiesta").load()
```

## Testing
After this change, the colorscheme loads successfully without errors.

Tested with:
```bash
nvim --headless -c 'colorscheme no-clown-fiesta' -c 'echo "SUCCESS"' -c 'q'
```

Fixes the module not found error that prevents the colorscheme from loading.